### PR TITLE
Default to expecting response when writing characteristic data

### DIFF
--- a/lib/central.js
+++ b/lib/central.js
@@ -118,8 +118,8 @@ Central.prototype.readServiceCharacteristic = function(serviceId, characteristic
  */
 Central.prototype.writeServiceCharacteristic = function(serviceId, characteristicId, value, callback) {
   this.getCharacteristic(serviceId, characteristicId, function(err, c) {
-    c.write(value, true, function(err) {
-      callback(err, null);
+    c.write(value, false, function() {
+      callback(null);
     });
   });
 };

--- a/spec/lib/central.spec.js
+++ b/spec/lib/central.spec.js
@@ -202,7 +202,7 @@ describe("Central", function() {
       );
 
       expect(characteristic.write).to.be.calledWith("value");
-      expect(callback).to.be.calledWith(null, null);
+      expect(callback).to.be.calledWith(null);
     });
   });
 


### PR DESCRIPTION
Default to expecting response when writing characteristic data, instead of the previous writeWithoutResponse.