### PR TITLE
Handle 'stateChange' event correctly in latest noble

### DIFF
--- a/lib/central.js
+++ b/lib/central.js
@@ -44,7 +44,11 @@ Central.prototype.connect = function(callback) {
     }
   }.bind(this));
 
-  this.bleConnect.startScanning();
+  this.bleConnect.on("stateChange", function(state) {
+    if (state === "poweredOn") {
+      this.bleConnect.startScanning();
+    }
+  }.bind(this));
 };
 
 /**

--- a/spec/lib/central.spec.js
+++ b/spec/lib/central.spec.js
@@ -54,7 +54,8 @@ describe("Central", function() {
       adaptor.connect(callback);
     });
 
-    it("starts scanning for peripherals", function() {
+    it("starts scanning for peripherals when powered on", function() {
+      bleConnect.on.yield("poweredOn");
       expect(bleConnect.startScanning).to.be.called;
     });
 


### PR DESCRIPTION
Handle 'stateChange' event correctly in latest noble, so we do not start scanning until the BLE adapter is ready.